### PR TITLE
XMOF configuration map: add new constructor to directly use dynamic objects + Java 1.8

### DIFF
--- a/org.modelexecution.xmof.configuration/.classpath
+++ b/org.modelexecution.xmof.configuration/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/org.modelexecution.xmof.configuration/.settings/org.eclipse.jdt.core.prefs
+++ b/org.modelexecution.xmof.configuration/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,7 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
-org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.7
+org.eclipse.jdt.core.compiler.source=1.8


### PR DESCRIPTION
To support cases where the XMOF engine is directely provided with
configuration objects (eg. GEMOC Studio), I've added a new constructor
with a boolean "providedAreConfiguration".

If providedAreConfiguration=true, we bypass the creation of all
configuration objects, and we simply fill the map to have each
configuration object point to itself. This ensures that existing code
relying on the configuration map will keep working.

Maybe instead this can be decided separately for each object: if original object, we create the configuration object and put the pair in the map; if conf object already, put the pair with the configuration object twice. But this will be the next pull request :) 
